### PR TITLE
hostname from conf, grep fixes

### DIFF
--- a/mm.sh
+++ b/mm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-hostname=$(hostname -f)
+hostname=$(grep -i "Hostname=" /etc/zabbix/zabbix_agentd.conf | sed 's/Hostname=//g')
 
 get_mysqld_sockets() {
 	ps uaxwww | grep -E 'mysqld.+--socket' | grep -Eo '[\/a-z-]+\.sock+'

--- a/mm.sh
+++ b/mm.sh
@@ -82,7 +82,7 @@ update_extended_status() {
 	for socket in $(get_mysqld_sockets)
 	do
 		check_alive ${socket}
-		instance=$(echo $socket | cut -d'/' -f5 | grep -Eo 'mysql[-a-z]+')
+		instance=$(echo $socket | cut -d'/' -f5 | grep -Eo 'mysql([-a-z]+)?')
 		mysql --defaults-extra-file=/etc/zabbix/.my.cnf -S ${socket} -e 'show GLOBAL status' \
 			| tail -n+2 \
 			| awk "{if (\$2 != \"\") print \"${hostname} mm.mysql.\" \$1 \"[${instance}]\"\" ${timestamp} \" \$2}" \
@@ -100,7 +100,7 @@ update_replication_status() {
 
 	for socket in $(get_mysqld_sockets)
 	do
-		instance=$(echo $socket | cut -d'/' -f5 | grep -Eo 'mysql[-a-z]+')
+		instance=$(echo $socket | cut -d'/' -f5 | grep -Eo 'mysql([-a-z]+)?')
 		replicas=$(get_slave_data ${socket} Connection_name)
 		for replica in ${replicas:-main}
 		do


### PR DESCRIPTION
Hostname not so important for most, but zabbix_sender fails to send .dat unless matched to what's on zabbix_server and that's usually what's in the agentd.conf moreso that `hostname`.

Was getting fails on the _senders due to instance name in key generated to .dat not matching key name with instance auto-discovered on _server, guess it might work if you instance names were blank (maybe related to the previous failing cut).